### PR TITLE
feat: update dependencies to be compatible with 3.15.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-auth-provider</artifactId>
             <version>${gravitee-resource-auth-provider.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Ldaptive -->

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>20.2</version>
     </parent>
 
     <groupId>io.gravitee.resource</groupId>
@@ -37,10 +37,10 @@
     <properties>
         <ldaptive.version>1.3.0</ldaptive.version>
 
-        <gravitee-bom.version>1.4</gravitee-bom.version>
+        <gravitee-bom.version>2.1</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>1.27.3</gravitee-gateway-api.version>
-        <gravitee-resource-auth-provider.version>1.2.0</gravitee-resource-auth-provider.version>
+        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
+        <gravitee-resource-auth-provider.version>1.3.0</gravitee-resource-auth-provider.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7198

**Description**

 - update dependencies to be compatible with 3.15.x
 - set gravitee-resource-auth-provider as provided since it will be provided by APIM
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.0-SNAPSHOT.apim-3-15-compatibility`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-auth-provider-ldap/1.3.0-SNAPSHOT.apim-3-15-compatibility/gravitee-resource-auth-provider-ldap-1.3.0-SNAPSHOT.apim-3-15-compatibility.zip)
  <!-- Version placeholder end -->
