### PR TITLE
feat: rework schema-form to use new GioJsonSchema Ui component

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -5,3 +5,4 @@ description=${project.description}
 class=io.gravitee.resource.authprovider.ldap.LdapAuthenticationProviderResource
 type=resource
 icon=ldap.png
+category=Authentication

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,6 +1,6 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:resource:authprovider:ldap:LdapIdentityProviderConfiguration",
   "properties" : {
     "contextSourceUrl" : {
       "type" : "string",
@@ -41,7 +41,8 @@
     },
     "attributes" : {
       "type" : "array",
-      "title": "User LDAP attributes to put in the request context. Attributes can then be read from any other policy supporting EL (gravitee.attribute.user.{attribute})",
+      "title": "User LDAP attributes",
+      "description": "User LDAP attributes to put in the request context. Attributes can then be read from any other policy supporting EL (gravitee.attribute.user.{attribute})",
       "items" : {
         "type" : "string",
         "title": "Ldap attribute",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2212

**Description**

![image](https://github.com/gravitee-io/gravitee-resource-auth-provider-ldap/assets/4974420/e0f2b84f-aff0-47ea-bc4e-216867827786)
![image](https://github.com/gravitee-io/gravitee-resource-auth-provider-inline/assets/4974420/e44885c7-f4e7-46c7-a6ea-5bf204e4b6dc)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-APIM-2364-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-auth-provider-ldap/1.4.0-APIM-2364-json-schema-SNAPSHOT/gravitee-resource-auth-provider-ldap-1.4.0-APIM-2364-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
