### PR TITLE
fix: Remove default value of User search base field from LDAP Resource

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,9 +79,9 @@ You can configure the resource with the following options :
 
 .^|userSearchBase
 ^.^|-
-|Search base within `contextSourceBase` used to search into the correct OU when validating user's credentials.
+|Search base within `contextSourceBase` used to search into the correct OU when validating user's credentials. If not supplied, the search will be performed using the Base DN (`contextSourceBase`).
 ^.^|string
-^.^|ou=users
+^.^|-
 ^.^|X
 ^.^|-
 

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -36,9 +36,8 @@
         },
         "userSearchBase": {
             "type": "string",
-            "default": "ou=users",
             "title": "User search base",
-            "description": "If user-search-base isn't supplied, the search will be performed using the base DN. (Supports EL)"
+            "description": "If user-search-base isn't supplied, the search will be performed using the base DN. (e.g. ou=users) (Supports EL)"
         },
         "attributes": {
             "type": "array",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12443

**Description**

Removed default value of User search base field so that 
The UI does not force a default value of "ou=users" into the field whenever the resource is loaded for editing, 
Which resulted in failed authentication if the user doesn't catch it before saving.



https://github.com/user-attachments/assets/c435d10e-f59a-4280-b475-1e3146aa58b0



<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-APIM-12443-Remove-Default-Val-from-User-search-base-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-auth-provider-ldap/2.0.1-APIM-12443-Remove-Default-Val-from-User-search-base-SNAPSHOT/gravitee-resource-auth-provider-ldap-2.0.1-APIM-12443-Remove-Default-Val-from-User-search-base-SNAPSHOT.zip)
  <!-- Version placeholder end -->
